### PR TITLE
Update Dagger

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,11 @@ task<JacocoReport>("jacocoTestReport") {
         "**/BuildConfig.*",
         "**/Manifest*.*",
         "**/*Binding.*",
-        "**/*Test*.*"
+        "**/*Test*.*",
+        // Dagger generated classes
+        "**/*_MembersInjector.*",
+        "**/Dagger*Component*.*",
+        "**/*Module_*Factory*.*"
     )
     val debugKotlinFileTree = fileTree("${project.buildDir}/tmp/kotlin-classes/debug") {
         exclude(fileFilter)

--- a/app/src/main/java/com/ephemeraldreams/androidbootstrap/ApplicationModule.kt
+++ b/app/src/main/java/com/ephemeraldreams/androidbootstrap/ApplicationModule.kt
@@ -11,13 +11,13 @@ import javax.inject.Singleton
 @Module(includes = [ApplicationModuleBinders::class])
 object ApplicationModule {
     @Provides @Singleton
-    fun provideContext(application: BootstrapApplication): Context = application.applicationContext
+    fun getContext(application: BootstrapApplication): Context = application.applicationContext
 
-    @Provides @ApplicationId
-    fun provideApplicationId(application: BootstrapApplication): String = application.packageName
+    @Provides @Singleton @ApplicationId
+    fun getApplicationId(application: BootstrapApplication): String = application.packageName
 }
 
 @Module
 abstract class ApplicationModuleBinders {
-    @Binds abstract fun provideApplication(bind: BootstrapApplication): Application
+    @Binds abstract fun getApplication(bind: BootstrapApplication): Application
 }

--- a/app/src/main/java/com/ephemeraldreams/androidbootstrap/data/DataModule.kt
+++ b/app/src/main/java/com/ephemeraldreams/androidbootstrap/data/DataModule.kt
@@ -10,5 +10,5 @@ import javax.inject.Singleton
 object DataModule {
 
     @Provides @Singleton
-    fun provideMoshi(): Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    fun getMoshi(): Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
 }

--- a/app/src/main/java/com/ephemeraldreams/androidbootstrap/net/NetworkModule.kt
+++ b/app/src/main/java/com/ephemeraldreams/androidbootstrap/net/NetworkModule.kt
@@ -14,7 +14,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor {
+    fun getHttpLoggingInterceptor(): HttpLoggingInterceptor {
         val httpLoggingInterceptor = HttpLoggingInterceptor(object : Logger {
             override fun log(message: String) {
                 if (BuildConfig.DEBUG) {
@@ -36,7 +36,7 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun providesOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor): OkHttpClient =
+    fun getOkHttpClient(httpLoggingInterceptor: HttpLoggingInterceptor): OkHttpClient =
         OkHttpClient.Builder()
             .addInterceptor(httpLoggingInterceptor)
             .build()

--- a/app/src/main/java/com/ephemeraldreams/androidbootstrap/ui/ActivityModule.kt
+++ b/app/src/main/java/com/ephemeraldreams/androidbootstrap/ui/ActivityModule.kt
@@ -7,6 +7,6 @@ import dagger.android.ContributesAndroidInjector
 
 @Module
 abstract class ActivityModule {
-    @ContributesAndroidInjector abstract fun provideHomeActivity(): HomeActivity
-    @ContributesAndroidInjector abstract fun provideSettingsActivity(): SettingsActivity
+    @ContributesAndroidInjector abstract fun getHomeActivity(): HomeActivity
+    @ContributesAndroidInjector abstract fun getSettingsActivity(): SettingsActivity
 }

--- a/buildSrc/src/main/kotlin/com/ephemeraldreams/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/ephemeraldreams/Dependencies.kt
@@ -88,7 +88,7 @@ object Dependencies {
 
     object Google {
         object Dagger {
-            private const val version = "2.26"
+            private const val version = "2.27"
             const val Dagger = "com.google.dagger:dagger:$version"
             const val Compiler = "com.google.dagger:dagger-compiler:$version"
             const val AndroidSupport = "com.google.dagger:dagger-android-support:$version"


### PR DESCRIPTION
- Update Dagger 2.26 -> 2.27
- Clean up Dagger modules
- Exclude generated Dagger classes from test coverage report